### PR TITLE
Enhance scripts for algo registration and job submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,21 @@ To register the algorithm (or re-register it after making code changes), run the
 following command:
 
 ```plain
-SAR2D2_ENV=<conda-env> nasa/algorithm/register.py
+nasa/algorithm/register.py
 ```
+
+> [!NOTE]
+>
+> The *first* time you run this command, it will *automatically* create an
+> isolated conda environment separate from your main environment.  This will
+> take a few moments, but subsequent algorithm and job commands will run much
+> more quickly, as the environment will be reused.  Further, the environment is
+> created in a location that persists across instance restarts.
+>
+> This separate environment is used automatically behind the scenes for running
+> all algorithm and job scripts that use `maap-py`.  This environment is built
+> to include *only* `maap-py` and its dependencies, and you should never need to
+> use this environment directly, nor even know where it is.
 
 This will kick off a process to build a new algorithm image, and will output a
 link where you can check the progress of this process, which may take several
@@ -42,30 +55,119 @@ minutes.  The new version of the algorithm will not be available for submitting
 jobs until this process completes successfully.  Once the process completes
 successfully, the new version of the algorithm is considered "registered."
 
+> [!NOTE]
+>
+> The *version* of the algorithm that is registered is set to the name of the
+> current branch that you have checked out, unless you have added a tag to the
+> current commit, in which case the version is set to the value of the tag.
+
 ## Submitting a job
 
 Once the algorithm is registered (or re-registered), you may submit a job using
 the following command:
 
 ```plain
-SAR2D2_ENV=<conda-env> nasa/job/submit.py CALIBRATION_FILE LEFT BOTTOM RIGHT TOP
+nasa/job/submit.py ARGS...
 ```
 
-where the arguments are the same as those used when running the algorithm
-locally (see above), with the following difference: if `CALIBRATION_FILE` is
-_not_ a URL, it will automatically be converted to a URL if its path starts with
-`/projects/my-public-bucket` or `/projects/shared-bucket/USERNAME` (where
-`USERNAME` is the username of any MAAP user, not necessarily your username).
+As with the registration command above, the *version* of the algorithm that is
+used is either the name of the current branch, or the value of the tag of the
+current commit, if there is a tag.  However, you *can* specify the `--version`
+option to override this, if you ever want to run a different version of the
+algorithm.
+
+The expected `ARGS` are *automatically* determined by the inputs defined in the
+`nasa/algorithm.yml` file.  Therefore, to see the expected arguments, run the
+following command:
+
+```plain
+nasa/job/submit.py -h
+```
+
+> [!NOTE]
+>
+> By default, the queue specified in the `nasa/algorithm.yml` file will be used,
+> but you can override this by including the `-q/--queue` option, as described
+> in the help message shown by the command above.
+>
+> Further, for any input defined in `nasa/algorithm.yml` that has a non-empty
+> default value specified, that input can be excluded from the command-line,
+> and the default value will be used.  To override the default, you can specify
+> a value on the command line by using an option rather than a positional
+> argument.  Again, the help message from the command above will describe the
+> supported options and positional arguments.
+
+> [!WARNING]
+>
+> Since the expected command line arguments are obtained from the
+> `nasa/algorithm.yml` file, if you override the version of the algorithm to run
+> by specifying the `--version` option, the job submission will fail if the
+> defined inputs are different between the two versions of the algorithm.
+
+Here's an example submission (which may not match the inputs currently defined
+in `nasa/algorithm.yml`, but should give you the idea):
+
+```plain
+nasa/job/submit.py https://datapool.asf.alaska.edu/L1.0/A3/ALPSRP271200670-L1.0.zip '-117.722 33.825 -118.61 34.483' alos1 l0b
+```
+
+To use the "sandbox" queue instead of the queue specified in the YAML file:
+
+```plain
+nasa/job/submit.py --queue maap-dps-sandbox https://datapool.asf.alaska.edu/L1.0/A3/ALPSRP271200670-L1.0.zip '-117.722 33.825 -118.61 34.483' alos1 l0b
+```
+
+To override the default GCOV posting:
+
+```plain
+nasa/job/submit.py --gcov_posting 0.0009 https://datapool.asf.alaska.edu/L1.0/A3/ALPSRP271200670-L1.0.zip '-117.722 33.825 -118.61 34.483' alos1 l0b
+```
+
+Of course, you can override the queue and other defaults simultaneously.
 
 If the job was successfully submitted, the command above will print out the job
 ID of the newly submitted job, which you can use to check the job status.
+
+> [!TIP]
+>
+> You can run the submit script from within a notebook, if you wish to use
+> values from the notebook as arguments to the script.
+>
+> Specifically, rather than making a call like so:
+>
+> ```plain
+> maap.submitJob(
+>     identifier="test_to_l0b",
+>     algo_id="sar2-d2",
+>     version="gcov_pipeline",
+>     username="niemoell",
+>     queue="maap-dps-sandbox",
+>     in_file=item,
+>     bbox=union_of_bboxes.get_as_str(),
+>     in_type="alos1",  # Choose from: 'alos1', 'l0b', 'rslc',
+>     out_type="l0b",  # Choose from: 'l0b', 'rslc', 'gcov'
+>     gcov_posting="0.000833334"
+> )
+> ```
+>
+> You can make a shell call like so:
+>
+> ```plain
+> !job/submit.py --identifier test_to_l0b --queue maap-dps-sandbox {item} '{union_of_bboxes.get_as_str()}' alos1 l0b
+> ```
+>
+> Notice that there's no need to specify `algo_id`, `version`, `username`, nor
+> `gcov_posting` because the script automatically uses the correct values,
+> although `version` and `gcov_posting` can be overridden, if needed.
+>
+> **Also notice the need for quotes around the bbox value!**
 
 ## Checking the status of a job
 
 After successfully submitting a job, you can use the job ID to check its status:
 
 ```plain
-SAR2D2_ENV=<conda-env> nasa/job/status.py JOB_ID
+nasa/job/status.py JOB_ID
 ```
 
 where `JOB_ID` is the job ID printed out by the job submission command.
@@ -73,7 +175,7 @@ where `JOB_ID` is the job ID printed out by the job submission command.
 You can also get more information about the job, using the following command:
 
 ```plain
-SAR2D2_ENV=<conda-env> nasa/job/result.py JOB_ID
+nasa/job/result.py JOB_ID
 ```
 
 If the job has completed, successfully or not, the command will indicate where

--- a/bin/conda/maap.sh
+++ b/bin/conda/maap.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+conda=${CONDA_EXE:-conda}
+thisdir=$(dirname "$(readlink -f "$0")")
+env_file=${thisdir}/maap.yml
+prefix=${HOME}/.conda/envs/maap
+
+# If the maap.yml file is newer than the conda env directory (prefix), then
+# update the conda env.  This should occur only the very first time this script
+# is executed, creating the conda env.  All subsequent uses of this script will
+# should run without updating the environment, as the maap.yml should not need
+# to be updated.
+
+if [[ "${env_file}" -nt "${prefix}" ]]; then
+    echo 1>&2
+    echo 1>&2 "Performing initial preparation for running MAAP algorithm and job commands."
+    echo 1>&2 "Subsequent algorithm and job commands will run without pause."
+    echo 1>&2
+    echo 1>&2 "This one-time step will take only a few moments ..."
+    echo 1>&2
+
+    "${conda}" env update --solver=libmamba --prefix="${prefix}" --file="${env_file}" >/dev/null
+fi
+
+"${conda}" run --no-capture-output --prefix "${prefix}" "${@}"

--- a/bin/conda/maap.yml
+++ b/bin/conda/maap.yml
@@ -1,0 +1,5 @@
+dependencies:
+  - python ~=3.13
+  - pip
+  - pip:
+      - maap-py

--- a/nasa/algorithm/list.py
+++ b/nasa/algorithm/list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S bin/conda/run.sh python
+#!/usr/bin/env -S bin/conda/maap.sh python
 
 """
 List registered NASA MAAP algorithms.

--- a/nasa/algorithm/register.py
+++ b/nasa/algorithm/register.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S bin/conda/run.sh python
+#!/usr/bin/env -S bin/conda/maap.sh python
 
 """
 Register this NASA MAAP algorithm using the file nasa/algorithm.yml.

--- a/nasa/job/result.py
+++ b/nasa/job/result.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S bin/conda/run.sh python
+#!/usr/bin/env -S bin/conda/maap.sh python
 
 """
 Get the result of a job.

--- a/nasa/job/status.py
+++ b/nasa/job/status.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S bin/conda/run.sh python
+#!/usr/bin/env -S bin/conda/maap.sh python
 
 """
 Get the status of a job.

--- a/nasa/job/submit.py
+++ b/nasa/job/submit.py
@@ -198,7 +198,6 @@ if __name__ == "__main__":
     username = get_username(maap)
     result = maap.submitJob(
         username=username,
-        identifier=name,
         algo_id=name,
         version=args.version,
         queue=args.queue,

--- a/nasa/job/submit.py
+++ b/nasa/job/submit.py
@@ -77,6 +77,11 @@ def build_parser(
     )
 
     parser.add_argument(
+        "--identifier",
+        help="an identifier you wish to use to identify the job",
+        default="unidentified",
+    )
+    parser.add_argument(
         "--version",
         help="version of the algorithm to use",
         default=default_version,

--- a/nasa/job/submit.py
+++ b/nasa/job/submit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S bin/conda/run.sh python
+#!/usr/bin/env -S bin/conda/maap.sh python
 
 """
 Submit a job using the NASA MAAP algorithm defined in the file nasa/algorithm.yml.

--- a/nasa/job/submit.py
+++ b/nasa/job/submit.py
@@ -107,7 +107,8 @@ def add_file_argument(
     # from urllib.parse import urlparse
 
     parser.add_argument(
-        input["name"].upper(),
+        input["name"],
+        metavar=input["name"].upper(),
         # TODO use a function that checks for valid http(s) URLs
         type=str,
         help=input.get("description"),
@@ -125,7 +126,8 @@ def add_positional_argument(
 ) -> argparse.ArgumentParser:
     if default := input.get("default"):
         parser.add_argument(
-            f"--{input['name'].replace('_', '-')}",
+            f"--{input['name']}",
+            metavar=input["name"].upper(),
             help=input.get("description"),
             default=default,
             # Do NOT include 'required' option because all positional arguments are
@@ -135,7 +137,8 @@ def add_positional_argument(
         )
     else:
         parser.add_argument(
-            input["name"].upper(),
+            input["name"],
+            metavar=input["name"].upper(),
             help=input.get("description"),
             # Do NOT include 'required' option because all positional arguments are
             # required by argparse, so argparse throws an error when you include

--- a/nasa/job/submit.py
+++ b/nasa/job/submit.py
@@ -13,11 +13,13 @@ If there is no tag value, the branch name is used.
 """
 
 import argparse
+import re
 import sys
 from pathlib import Path
-from typing import NoReturn, Sequence
+from typing import Any, Mapping, NoReturn, Sequence
 
 import requests
+import yaml
 from maap.maap import MAAP  # type: ignore
 
 
@@ -61,51 +63,10 @@ def to_url(path: str, username: str) -> str:
     return url
 
 
-def parse_args(username: str, args: Sequence[str]) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Submit a MAAP DPS job")
-    parser.add_argument(
-        "calibration_file",
-        type=lambda arg: to_url(arg, username),
-        help="path to calibration file",
-        metavar="calibration-file",
-    )
-    parser.add_argument(
-        "left",
-        type=float,
-        help="left longitude of your desired bounding box",
-    )
-    parser.add_argument(
-        "bottom",
-        type=float,
-        help="bottom latitude of your desired bounding box",
-    )
-    parser.add_argument(
-        "right",
-        type=float,
-        help="right longitude of your desired bounding box",
-    )
-    parser.add_argument(
-        "top",
-        type=float,
-        help="top latitude of your desired bounding box",
-    )
-
-    return parser.parse_args(args)
-
-
-if __name__ == "__main__":
-    import json
-    import os
-    import subprocess
-
-    maap = MAAP()
-    username = get_username(maap)
-    args = parse_args(username, sys.argv[1:])
-    calibration_file = args.calibration_file
-    bbox = f"{args.left} {args.bottom} {args.right} {args.top}"
-
-    name = os.environ["CONDA_DEFAULT_ENV"]
-    version = (
+def build_parser(
+    parser: argparse.ArgumentParser, config: Mapping[str, Any]
+) -> argparse.ArgumentParser:
+    default_version = (
         subprocess.run(["git", "tag", "--points-at", "HEAD"], capture_output=True)
         .stdout.decode()
         .strip()
@@ -115,14 +76,125 @@ if __name__ == "__main__":
         .strip()
     )
 
+    parser.add_argument(
+        "--version",
+        help="version of the algorithm to use",
+        default=default_version,
+    )
+    parser.add_argument(
+        "--queue",
+        "-q",
+        help="name of the job queue to use",
+        default=config.get("queue"),
+    )
+
+    inputs = config.get("inputs", {})
+    file_inputs = inputs.get("file", [])
+    positional_inputs = inputs.get("positional", [])
+
+    for file_input in file_inputs:
+        add_file_argument(parser, file_input)
+
+    for positional_input in positional_inputs:
+        add_positional_argument(parser, positional_input)
+
+    return parser
+
+
+def add_file_argument(
+    parser: argparse.ArgumentParser, input: Mapping[str, Any]
+) -> argparse.ArgumentParser:
+    # from urllib.parse import urlparse
+
+    parser.add_argument(
+        input["name"].upper(),
+        # TODO use a function that checks for valid http(s) URLs
+        type=str,
+        help=input.get("description"),
+        # Do NOT include 'required' option because all positional arguments are
+        # required by argparse, so argparse throws an error when you include
+        # this option.
+        # required=input.get("required", False),
+    )
+
+    return parser
+
+
+def add_positional_argument(
+    parser: argparse.ArgumentParser, input: Mapping[str, Any]
+) -> argparse.ArgumentParser:
+    if default := input.get("default"):
+        parser.add_argument(
+            f"--{input['name'].replace('_', '-')}",
+            help=input.get("description"),
+            default=default,
+            # Do NOT include 'required' option because all positional arguments are
+            # required by argparse, so argparse throws an error when you include
+            # this option.
+            # required=input.get("required", False),
+        )
+    else:
+        parser.add_argument(
+            input["name"].upper(),
+            help=input.get("description"),
+            # Do NOT include 'required' option because all positional arguments are
+            # required by argparse, so argparse throws an error when you include
+            # this option.
+            # required=input.get("required", False),
+        )
+
+    return parser
+
+
+def parse_args(args: Sequence[str]) -> tuple[str, argparse.Namespace]:
+    default_config_yaml = Path(__file__).parent.parent / "algorithm.yml"
+
+    parser = argparse.ArgumentParser(
+        description="Submit a MAAP DPS job",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    # TODO support alternative config yaml file (only nasa/algorithm.yml for now)
+    # TODO see argparse.parse_known_args for help with this
+    # parser.add_argument(
+    #     "--config",
+    #     type=str,
+    #     help="path to algorithm configuration YAML file",
+    #     metavar="YAML",
+    #     default=default_config_yaml.relative_to(Path.cwd()),
+    # )
+
+    config = yaml.safe_load(default_config_yaml.read_text())
+    name = config["algorithm_name"]
+
+    build_parser(parser, config)
+
+    return name, parser.parse_args(args)
+
+
+if __name__ == "__main__":
+    import json
+    import os
+    import subprocess
+
+    name, args = parse_args(sys.argv[1:])
+    version = args.version
+    queue = args.queue
+    inputs = {
+        name: value
+        for name, value in vars(args).items()
+        if name not in {"version", "queue"}
+    }
+
+    maap = MAAP()
+    username = get_username(maap)
     result = maap.submitJob(
         username=username,
         identifier=name,
         algo_id=name,
-        version=version,
-        queue="maap-dps-worker-32vcpu-64gb",
-        calibration_file=calibration_file,
-        bbox=bbox,
+        version=args.version,
+        queue=args.queue,
+        **inputs,
     )
     job_id = result.id
     error_details = result.error_details
@@ -130,4 +202,4 @@ if __name__ == "__main__":
     if not job_id:
         die(f"{error_details}" if error_details else json.dumps(result, indent=2))
 
-    print(f"Submitted job for algorithm {name}:{version} with job ID {job_id}")
+    print(f"Submitted job for algorithm {name}:{args.version} with job ID {job_id}")


### PR DESCRIPTION
@nemo794, I believe these enhancements to the algorithm registration and job submission scripts should help you.

I've added all the details to the `README.md`, so I won't repeat them here.

I used the scripts myself, within the ADE to both register the algo, and submit a job, so if you merge these changes into your branch, you should be able to do the same.

I ran the following to register (you'll need to do this as well once you merge this PR, because the registration uses the branch name as the algo version -- for example, when you run the following from your `gcov_pipeline` branch, after merging, it will automatically register the algo `sar2-d2:gcov_pipeline`, using the `nasa/algorithm.yml` file):

```plain
nasa/algorithm/register.py
```

Again, see the README.md for details, but the gist is that these algo and job commands now use their own separate conda env (created automatically) that contains only `maap-py` since that's all the commands need. There's no interference with the primary conda env that your algorithm code requires.

Once the registration completes (the script above prints the URL where you can check the registration progress to see when it completes), you can then submit jobs.

I submitted the following during my testing:

```plain
nasa/job/submit.py --queue maap-dps-sandbox https://datapool.asf.alaska.edu/L1.0/A3/ALPSRP271200670-L1.0.zip '-117.722 33.825 -118.61 34.483' alos1 l0b
```

You should be able to run the script from inside your notebook as well. The README.md shows an example of doing so, although I have not tested that myself.

Note that since these commands use a completely separate conda env specifically for maap-py commands, there's no need to prefix them with `SAR2D2_ENV=<env-name>` like you do for the `run.sh` script.