### PR TITLE
Add seed for use with the random number generator

### DIFF
--- a/src/cum_sum_dist/defaults/dist_algorithm.yaml
+++ b/src/cum_sum_dist/defaults/dist_algorithm.yaml
@@ -30,5 +30,6 @@ runconfig:
             forest_mask_threshold: -35 # dB
             bootstrap_number: 20
             confidence_threshold: 0.9
+            seed_for_random: null
 
         log_file: None

--- a/src/cum_sum_dist/dist_main.py
+++ b/src/cum_sum_dist/dist_main.py
@@ -442,9 +442,7 @@ def dist_workflow(cfg):
             n_bootstraps = bootstrap_number
             print(f"Number of bootstraps in the trial run {n_bootstraps}")
             # Prepare arguments for each iteration
-            args_list = [
-                (qmetric_residuals, dmask, seed_for_random) for _ in range(n_bootstraps)
-            ]
+            args_list = [(qmetric_residuals, dmask, seed_for_random)] * n_bootstraps            
 
             # Run in parallel
             with ProcessPoolExecutor() as executor:

--- a/src/cum_sum_dist/dist_main.py
+++ b/src/cum_sum_dist/dist_main.py
@@ -57,8 +57,9 @@ def run_bootstrap(args):
 
 def bootstrap_trial(args):
     """Single bootstrap iteration."""
-    qmetric_residuals, dmask = args
+    qmetric_residuals, dmask, seed = args
     # Shuffle time axis for permutation
+    np.random.seed(seed)
     permutation = np.random.permutation(len(qmetric_residuals["time"]))
     Srandom = qmetric_residuals.isel(time=permutation).cumsum("time")
     Srandom = Srandom.where(dmask)
@@ -125,6 +126,7 @@ def dist_workflow(cfg):
     resamp_out_res = cfg.groups.product_path_group.output_spacing
     confidence_threshold = proc_param.confidence_threshold
     filter_option = {"lambda_value": proc_param.filter_lambda}
+    seed_for_random = proc_param.seed_for_random
 
     polarizations = util.extract_nisar_polarization(input_gcov_list)
     date_str_list = []
@@ -440,7 +442,9 @@ def dist_workflow(cfg):
             n_bootstraps = bootstrap_number
             print(f"Number of bootstraps in the trial run {n_bootstraps}")
             # Prepare arguments for each iteration
-            args_list = [(qmetric_residuals, dmask) for _ in range(n_bootstraps)]
+            args_list = [
+                (qmetric_residuals, dmask, seed_for_random) for _ in range(n_bootstraps)
+            ]
 
             # Run in parallel
             with ProcessPoolExecutor() as executor:

--- a/src/cum_sum_dist/schemas/dist_algorithm.yaml
+++ b/src/cum_sum_dist/schemas/dist_algorithm.yaml
@@ -16,6 +16,7 @@ runconfig:
             forest_mask_threshold: num(required=False)
             bootstrap_number: int(min=1, required=False)
             confidence_threshold: num(min=0, max=1, required=False)
+            seed_for_random: int(min=0, required=False)
 
         product_path_group:
             # Directory where SAS can write temporary data


### PR DESCRIPTION
Currently, the algorithm uses a random number generator for the bootstrapping step. There was no way to seed the random number generator in order to reproduce exact results; this is necessary during development to create golden test datasets, unit tests, etc.

This PR introduces a seed into the algorithm, which is controllable from the runconfig. By default, the seed is set to `null`, which means the algorithm will generate a random number and be non-deterministic.